### PR TITLE
resolve latam mirror logic (Issue #15)

### DIFF
--- a/scripts/latAmMirror.st
+++ b/scripts/latAmMirror.st
@@ -1,12 +1,12 @@
 "If latam mirror isn't available, take our chances with squeaksource"
 (NetNameResolver addressForName: 'dsal.cl') ifNil: [ ^ self ].  
 "if latam mirror is available, need to install from mirror, in case squeaksource is down"
-Gofer new
-    url: 'http://dsal.cl/squeaksource/';
-    package: 'ObjectAsMethodWrapper';
-    load.
-Gofer new
-    url: 'http://dsal.cl/squeaksource/';
-    package: 'MontiRedirect';
-    load.
+Gofer new 
+  url: 'http://dsal.cl/squeaksource/ObjectsAsMethodsWrap'; 
+  package: 'ObjectAsMethodWrapper'; 
+  load.
+Gofer new 
+  url: 'http://dsal.cl/squeaksource/MonticelloRedirect'; 
+  package: 'MontiRedirect'; 
+  load.
 (Smalltalk at: #'MRManager') redirectFrom: 'http://www.squeaksource.com/' to: 'http://dsal.cl/squeaksource/'


### PR DESCRIPTION
@frankshearar I'd like you to look at and comment on the changes that I've made to the latam mirror ... of course the code works today because both squeaksource and the mirror are up...

I changed your code a bit, because if squeaksource was down, we wouldn't be able to load that latam mirror code...now we load and install the latam mirror code if latam is available ...
