### PR TITLE
Install 32bit libraries (64bit vms now)

### DIFF
--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -12,6 +12,7 @@ env:
 
 # Boilerplate ... should be no reason to edit the install section
 install:
+   - sudo apt-get install -qq ia32-libs-multiarch
    - export PROJECT_HOME="$(pwd)"
    - cd $HOME
    - wget -O builderCI.zip https://github.com/dalehenrich/builderCI/zipball/master


### PR DESCRIPTION
Travis has 64bit VMs now, so we need to install 32bit libraries before we can run Squeak vms.
