### PR TITLE
Install 32bit libraries (64bit vms now)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
    - ./build_image.sh
 
 script:
+   - sudo apt-get install -qq ia32-libs-multiarch
 #   - ./build.sh -i $ST -s latAmMirror.st -m -f "$BUILDER_CI_HOME/tests/travisCI.st" -o travisCI
    - ./build.sh -i $ST -m -f "$BUILDER_CI_HOME/tests/travisCI.st" -o travisCI
    - if ( test -e FAILED_VM_EXECUTION ); then exit 1; fi


### PR DESCRIPTION
Travis has 64bit VMs now, so we need to install 32bit libraries before we can run Squeak vms.
