### PR TITLE
Use libssl0.9.8:i386 for SqueakSSL

### DIFF
--- a/build_client_image.sh
+++ b/build_client_image.sh
@@ -20,7 +20,7 @@ case "$(uname -m)" in
                 # UUIDPlugin
                 sudo apt-get -qq install libuuid1:i386
                 # SqueakSSL
-                sudo apt-get -qq install libssl0.9.8:i386 libkrb5-3:i386 libk5crypto3:i386 zlib1g:i386 libcomerr2:i386 libkrb5support0:i386 libkeyutils1:i386
+                sudo apt-get -qq install libssl0.9.8:i386 libssl1.0.0:i386 libkrb5-3:i386 libk5crypto3:i386 zlib1g:i386 libcomerr2:i386 libkrb5support0:i386 libkeyutils1:i386
                 
                 if [ $SCREENSHOT ]; then
                     sudo apt-get -qq install libx11-6:i386 libgl1-mesa-swx11:i386 libsm6:i386


### PR DESCRIPTION
Unfortunately, SqueakSSL does not support libssl1.0.0 yet.

More information:
http://forum.world.st/Squeak-and-SSL-td4760579.html
