### PR TITLE
Let "neither SUCCESS nor FAILURE" result in failed builds

### DIFF
--- a/buildTravisStatusCheck.sh
+++ b/buildTravisStatusCheck.sh
@@ -28,6 +28,6 @@ if [ "$1" = "-verbose" ] ; then
   $BUILDER_CI_HOME/dumpTranscript.sh
 fi
 # exit with non-zero status except if builderCI is tested
-if [ "$1" != "-testBuilderCI" ] && [ "$2" != "-testBuilderCI" ] ; then
+if [ -z $TEST_BUILDERCI ] ; then
   exit 1
 fi

--- a/testBuilderCI.sh
+++ b/testBuilderCI.sh
@@ -8,8 +8,10 @@
 # Copyright (C) 2014 GemTalk Systems LLC <dale.henrichs@gemtalksystems.com>
 #
 
+export TEST_BUILDERCI=true
+
 #run tests
-./testTravisCI.sh "$@ -testBuilderCI"
+./testTravisCI.sh "$@"
 if [[ $? != 0 ]] ; then exit 1; fi
 
 # make sure that system runs okay when you skip the metacello bootstrap step
@@ -25,5 +27,5 @@ fi
 cd "${BUILD_PATH}/travisCI/"
 $BUILDER_CI_HOME/buildImageErrorCheck.sh
 if [[ $? != 0 ]] ; then exit 1; fi
-$BUILDER_CI_HOME/buildTravisStatusCheck.sh "$@ -testBuilderCI"
+$BUILDER_CI_HOME/buildTravisStatusCheck.sh "$@"
 if [[ $? != 0 ]] ; then exit 1; fi


### PR DESCRIPTION
Hi Dale,

I think it makes more sense to let "neither SUCCESS nor FAILURE" state result in failed builds.
I've seen projects with faulty baselines that pass builds which isn't what we want...

Hope you agree!

Regards,
Fabio
