### PR TITLE
Updated URL for Squeak-Trunk sources file

### DIFF
--- a/build_client_image.sh
+++ b/build_client_image.sh
@@ -105,7 +105,7 @@ case "$ST" in
     cd Squeak4.4
     wget -q http://ftp.squeak.org/4.4/Squeak4.4-12327.zip
     unzip Squeak4.4-12327.zip
-    wget -q http://ftp.squeak.org/4.4/SqueakV41.sources.gz
+    wget -q http://ftp.squeak.org/sources_files/SqueakV41.sources.gz
     gunzip SqueakV41.sources.gz
     IMAGE_BASE_NAME=Squeak4.4-12327
     ;;
@@ -118,7 +118,7 @@ case "$ST" in
     cd Squeak4.5
     wget -q http://ftp.squeak.org/4.5/Squeak4.5-13680.zip
     unzip Squeak4.5-13680.zip
-    wget -q http://ftp.squeak.org/4.5/SqueakV41.sources.gz
+    wget -q http://ftp.squeak.org/sources_files/SqueakV41.sources.gz
     gunzip SqueakV41.sources.gz
     IMAGE_BASE_NAME=Squeak4.5-13680
     ;;

--- a/build_client_image.sh
+++ b/build_client_image.sh
@@ -129,7 +129,7 @@ case "$ST" in
     cd TrunkImage
     wget -q http://build.squeak.org/job/SqueakTrunk/lastSuccessfulBuild/artifact/target/TrunkImage.zip
     unzip TrunkImage.zip
-    wget -q http://ftp.squeak.org/4.1/SqueakV41.sources.gz
+    wget -q http://ftp.squeak.org/4.5/SqueakV41.sources.gz
     gunzip SqueakV41.sources.gz
     IMAGE_BASE_NAME=TrunkImage
     ;;

--- a/build_client_image.sh
+++ b/build_client_image.sh
@@ -92,7 +92,7 @@ case "$ST" in
     wget -q http://ftp.squeak.org/4.3/Squeak4.3.zip
     unzip Squeak4.3.zip
     cd Squeak4.3
-    wget -q http://ftp.squeak.org/4.1/SqueakV41.sources.gz
+    wget -q http://ftp.squeak.org/sources_files/SqueakV41.sources.gz
     gunzip SqueakV41.sources.gz
     IMAGE_BASE_NAME=Squeak4.3
     ;;
@@ -129,7 +129,7 @@ case "$ST" in
     cd TrunkImage
     wget -q http://build.squeak.org/job/SqueakTrunk/lastSuccessfulBuild/artifact/target/TrunkImage.zip
     unzip TrunkImage.zip
-    wget -q http://ftp.squeak.org/4.5/SqueakV41.sources.gz
+    wget -q http://ftp.squeak.org/sources_files/SqueakV41.sources.gz
     gunzip SqueakV41.sources.gz
     IMAGE_BASE_NAME=TrunkImage
     ;;


### PR DESCRIPTION
Apparently, the folder for Squeak `4.1` was removed from [http://ftp.squeak.org/](http://ftp.squeak.org/), so this changes the script to use the same 4.1 sources file from the `4.5` folder instead.