### PR TITLE
Improve display handling for Squeak builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
    - ST=Pharo-2.0 
    - ST=Pharo-3.0
    - ST=Squeak-4.3
-#   - ST=Squeak-4.4               # see https://github.com/dalehenrich/builderCI/issues/86
-#   - ST=Squeak-4.5 SCREENSHOT=30 # see https://github.com/dalehenrich/builderCI/issues/86
+   - ST=Squeak-4.4
+   - ST=Squeak-4.5 SCREENSHOT=30
    - ST=GemStone-2.4.4.1
    - ST=GemStone-2.4.4.8
    - ST=GemStone-2.4.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: erlang
 env:
 
    - ST=Pharo-4.0
-   - ST=Squeak-Trunk # See https://github.com/dalehenrich/builderCI/issues/75 cannot use SCREENSHOT=30 with the TRUNK
+   - ST=Squeak-Trunk SCREENSHOT=60
    - ST=GemStone-3.2.4
 
    - ST=PharoCore-1.1

--- a/build_client.sh
+++ b/build_client.sh
@@ -165,8 +165,9 @@ fi
 
 case "$ST" in
     Squeak*|Pharo*)
-        echo "STARTING xvfb"
+        echo "STARTING xvfb ($DISPLAY)"
         sh -e /etc/init.d/xvfb start
+        sleep 2
         ;;
 esac
 

--- a/build_client.sh
+++ b/build_client.sh
@@ -166,7 +166,6 @@ fi
 case "$ST" in
     Squeak*|Pharo*)
         echo "STARTING xvfb"
-        export DISPLAY=:99.0
         sh -e /etc/init.d/xvfb start
         ;;
 esac

--- a/build_env_vars
+++ b/build_env_vars
@@ -13,4 +13,4 @@ export SOURCES_PATH="$BASE_PATH/sources"
 export VM_PATH="$BASE_PATH/oneclick/Contents"
 export BUILD_CACHE="$BASE_PATH/cache"
 export GIT_PATH="$IMAGES_PATH/git_cache"
-
+export DISPLAY=:99.0


### PR DESCRIPTION
This addresses #86.

I've moved `DISPLAY` to build_env_vars and I've given xvfb some time to start up.
Maybe this still isn't enough and we have to somehow check if xvfb is up and running normally.