### PR TITLE
Set dummy author initials in template build script

### DIFF
--- a/templates/travisCI.st
+++ b/templates/travisCI.st
@@ -1,10 +1,6 @@
 | gitPath gitCache |
 Transcript cr; show: 'travis---->travisCI.st'.
 
-"If e.g. your tests change code in the image dynamically, the image will require you to set 
-author initials which might fail these tests. So we set some dummy initials here to avoid this."
-Utilities setAuthorInitials: 'travisCI'.
-
 gitCache := 'git_cache'.
 gitPath := (Smalltalk at: #'FileDirectory' ifAbsent: [  ])
   ifNil: [ ((Smalltalk at: #'FileSystem') workingDirectory / gitCache) pathString ]
@@ -27,6 +23,10 @@ Metacello new
   baseline: '<projectName>';
   repository: 'filetree://', gitPath, '/<projectName>/<path to filetree packages root>';
   load: 'TravisCI'.
+  
+"If e.g. your tests change code in the image dynamically, the image will require you to set 
+author initials which might fail these tests. So we set some dummy initials here to avoid this."
+(Smalltalk at: #MetacelloPlatform) current authorName: 'travisCI'.
 
 "Run the tests"
 TravisCIHarness

--- a/templates/travisCI.st
+++ b/templates/travisCI.st
@@ -1,6 +1,10 @@
 | gitPath gitCache |
 Transcript cr; show: 'travis---->travisCI.st'.
 
+"If e.g. your tests change code in the image dynamically, the image will require you to set 
+author initials which might fail these tests. So we set some dummy initials here to avoid this."
+Utilities setAuthorInitials: 'travisCI'.
+
 gitCache := 'git_cache'.
 gitPath := (Smalltalk at: #'FileDirectory' ifAbsent: [  ])
   ifNil: [ ((Smalltalk at: #'FileSystem') workingDirectory / gitCache) pathString ]


### PR DESCRIPTION
Avoids failing tests and/or stuck in tests while waiting for the user to set the author initials.