### PR TITLE
SqueakSSL follow-up

### DIFF
--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -1,3 +1,4 @@
+sudo: true
 language: erlang
 
 # Choose which platforms you want your builds run against (done in parallel)


### PR DESCRIPTION
The SqueakSSL plugin for Linux has been updated once more.

Sorry about all the hassle.