### PR TITLE
It should be libfreetype6:i386

### DIFF
--- a/build_client_image.sh
+++ b/build_client_image.sh
@@ -33,7 +33,7 @@ case "$(uname -m)" in
                     Pharo*)
                       sudo apt-get -qq install libssl1.0.0:i386
                       # libFT2Plugin
-                      sudo apt-get -qq install libfreetype6
+                      sudo apt-get -qq install libfreetype6:i386
                 esac
                 ;;
         *)


### PR DESCRIPTION
As the title says... To correct that error:

libfreetype.so.6: cannot open shared object file: No such file or directory

https://travis-ci.org/dalehenrich/filetree/builds/118978824#L371
